### PR TITLE
Use TranslatorInterface instead of specific class

### DIFF
--- a/src/LinkBlockRepository.php
+++ b/src/LinkBlockRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-use \PrestaShopBundle\Translation\TranslatorComponent as Translator;
+use Symfony\Component\Translation\TranslatorInterface as Translator;
 
 class LinkBlockRepository
 {


### PR DESCRIPTION
Will prevent fatal error when the legacy `Context` will reuse the translator already instantiated by Symfony