### PR TITLE
 Material icons should not be translatable.

### DIFF
--- a/views/templates/admin/linkwidget/helpers/form/form.tpl
+++ b/views/templates/admin/linkwidget/helpers/form/form.tpl
@@ -234,7 +234,7 @@
                 </tr>
                 {foreach $input.values[$lang['id_lang']] as $key => $page}
                   <tr {if $key%2}class="alt_row"{/if} data-item="{$key}">
-                    <td><a href="#" class="js-clear-custom-link"><i class="material-icons action-disabled">{l s='Clear' d='Admin.Actions'}</i></a></td>
+                    <td><a href="#" class="js-clear-custom-link"><i class="material-icons action-disabled">clear</i></a></td>
                     <td>
                       <label class="control-label">
                         <input type="text" name="custom[{$lang['id_lang']}][{$key}][title]" value="{$page.title}"/>


### PR DESCRIPTION
See https://crowdin.com/translate/prestashop-official/32980/en-fr#5721356
Without translation: https://www.screencast.com/t/ut9rqi23
With translation: https://www.screencast.com/t/nlAq9CAYPB
The way to go: https://material.io/icons/#ic_clear