### PR TITLE
Fo: fix custom link id

### DIFF
--- a/src/Presenter/LinkBlockPresenter.php
+++ b/src/Presenter/LinkBlockPresenter.php
@@ -209,7 +209,7 @@ class LinkBlockPresenter
             $self = $this;
             $customLinks = array_map(function ($el) use ($self) {
                 return array(
-                    'id' => 'link-custom-page-' . $el['title'],
+                    'id' => 'link-custom-page-' . Tools::link_rewrite($el['title']),
                     'class' => 'custom-page-link',
                     'title' => $el['title'],
                     'description' => '',


### PR DESCRIPTION
Fixing id attribute when title have spaces

exemple:
$el['title'] = My title;
'id' => 'link-custom-page-'.$el['title']  become  id="link-custom-page-My title-2", this is not a valid id
