### PR TITLE
Corection wrong working as widget

### DIFF
--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -126,6 +126,9 @@ class Ps_Linklist extends Module implements WidgetInterface
 
     public function renderWidget($hookName, array $configuration)
     {
+        if ($hookName == null && isset($configuration['hook'])) {
+            $hookName = $configuration['hook'];
+        }
         $key = 'ps_linklist|' . $hookName;
 
         if (!$this->isCached($this->templateFile, $this->getCacheId($key))) {


### PR DESCRIPTION
When using in some template this way as widget:
 {widget name="ps_linklist" hook="displayFooter"}
then module make no output, beacuse in this case in method renderWidget() parameter $hookName is null and there was no read from $configuration['hook']