### PR TITLE
Use the new feature from 177 for automatic tabs and Symfony route

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_linklist</name>
     <displayName><![CDATA[Link List]]></displayName>
-    <version><![CDATA[3.2.0]]></version>
+    <version><![CDATA[4.0.0]]></version>
     <description><![CDATA[Adds a block with several links.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/config/routes.yml
+++ b/config/routes.yml
@@ -4,6 +4,7 @@ admin_link_block_list:
   defaults:
     _controller: 'PrestaShop\Module\LinkList\Controller\Admin\Improve\Design\LinkBlockController::listAction'
     _legacy_controller: AdminLinkWidget
+    _legacy_link: AdminLinkWidget
 
 admin_link_block_create:
   path: /link-widget/create

--- a/config/routes.yml
+++ b/config/routes.yml
@@ -4,7 +4,6 @@ admin_link_block_list:
   defaults:
     _controller: 'PrestaShop\Module\LinkList\Controller\Admin\Improve\Design\LinkBlockController::listAction'
     _legacy_controller: AdminLinkWidget
-    _legacy_link: AdminLinkWidget
 
 admin_link_block_create:
   path: /link-widget/create

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -65,12 +65,17 @@ class Ps_Linklist extends Module implements WidgetInterface
         $this->version = '4.0.0';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
+
+        $tabNames = [];
+        foreach (Language::getLanguages(true) as $lang) {
+            $tabNames[$lang['id_lang']] = $this->trans('Link List', array(), 'Modules.Linklist.Admin', $lang['locale']);
+        }
         $this->tabs = [
             [
                 'route_name' => 'admin_link_block_list',
                 'class_name' => 'AdminLinkWidget',
                 'visible' => true,
-                'name' => 'Link Widget',
+                'name' => $tabNames,
                 'parent_class_name' => 'AdminParentThemes',
             ],
         ];

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -163,8 +163,11 @@ class Ps_Linklist extends Module implements WidgetInterface
 
     public function getContent()
     {
+        // We need to explicitely get Symfony container, because $this->>get will use the admin legacy container
+        $sfContainer = SymfonyContainer::getInstance();
+        $router = $sfContainer->get('router');
         Tools::redirectAdmin(
-            $this->context->link->getAdminLink('AdminLinkWidget')
+            $router->generate('admin_link_block_list')
         );
     }
 

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -67,6 +67,7 @@ class Ps_Linklist extends Module implements WidgetInterface
         $this->tab = 'front_office_features';
         $this->tabs = [
             [
+                'route_name' => 'admin_link_block_list',
                 'class_name' => 'AdminLinkWidget',
                 'visible' => true,
                 'name' => 'Link Widget',
@@ -81,7 +82,7 @@ class Ps_Linklist extends Module implements WidgetInterface
         $this->description = $this->trans('Adds a block with several links.', array(), 'Modules.Linklist.Admin');
         $this->secure_key = Tools::encrypt($this->name);
 
-        $this->ps_versions_compliancy = array('min' => '1.7.5.0', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '1.7.7.0', 'max' => _PS_VERSION_);
         $this->templateFile = 'module:ps_linklist/views/templates/hook/linkblock.tpl';
 
         $this->linkBlockPresenter = new LinkBlockPresenter(new Link(), $this->context->language);
@@ -98,23 +99,13 @@ class Ps_Linklist extends Module implements WidgetInterface
 
         if ($installed
             && $this->registerHook('displayFooter')
-            && $this->registerHook('actionUpdateLangAfter')
-            && $this->installTab()) {
+            && $this->registerHook('actionUpdateLangAfter')) {
             return true;
         }
 
         $this->uninstall();
 
         return false;
-    }
-
-    public function enable($force_all = false)
-    {
-        if (!$this->installTab()) {
-            return false;
-        }
-
-        return parent::enable($force_all);
     }
 
     /**
@@ -156,33 +147,6 @@ class Ps_Linklist extends Module implements WidgetInterface
         }
 
         return $uninstalled && parent::uninstall();
-    }
-
-    /**
-     * The Core is supposed to register the tabs automatically thanks to the getTabs() return.
-     * However in 1.7.5 it only works when the module contains a AdminLinkWidgetController file,
-     * this works fine when module has been upgraded and the former file is still present however
-     * for a fresh install we need to install it manually until the core is able to manage new modules.
-     *
-     * @return bool
-     */
-    public function installTab()
-    {
-        if (Tab::getIdFromClassName('AdminLinkWidget')) {
-            return true;
-        }
-
-        $tab = new Tab();
-        $tab->active = 1;
-        $tab->class_name = 'AdminLinkWidget';
-        $tab->name = array();
-        foreach (Language::getLanguages(true) as $lang) {
-            $tab->name[$lang['id_lang']] = 'Link Widget';
-        }
-        $tab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
-        $tab->module = $this->name;
-
-        return $tab->add();
     }
 
     public function hookActionUpdateLangAfter($params)

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -62,7 +62,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $this->name = 'ps_linklist';
         $this->author = 'PrestaShop';
-        $this->version = '3.2.0';
+        $this->version = '4.0.0';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
         $this->tabs = [

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -68,7 +68,7 @@ class Ps_Linklist extends Module implements WidgetInterface
 
         $tabNames = [];
         foreach (Language::getLanguages(true) as $lang) {
-            $tabNames[$lang['id_lang']] = $this->trans('Link List', array(), 'Modules.Linklist.Admin', $lang['locale']);
+            $tabNames[$lang['locale']] = $this->trans('Link List', array(), 'Modules.Linklist.Admin', $lang['locale']);
         }
         $this->tabs = [
             [
@@ -168,7 +168,7 @@ class Ps_Linklist extends Module implements WidgetInterface
 
     public function getContent()
     {
-        // We need to explicitely get Symfony container, because $this->>get will use the admin legacy container
+        // We need to explicitely get Symfony container, because $this->get will use the admin legacy container
         $sfContainer = SymfonyContainer::getInstance();
         $router = $sfContainer->get('router');
         Tools::redirectAdmin(

--- a/upgrade/upgrade-4.0.php
+++ b/upgrade/upgrade-4.0.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_0($object)
+{
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'tab` SET `route_name` = "admin_link_block_list" WHERE `class_name` = "AdminLinkWidget"');
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR uses a new feature from the 177 that allows to use Symfony routes in the `$tabs` parameter, thus allowing not to use the `_legacy_link` any more It was kept in the routing though for backward compatibility but it's not necessary any more in the Tab
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Try to install/uninstall the module, the tab should still work You can also try to enable/disable the module the Tab is show/hidden in the BO menu

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

# WARNING

Before merging this PR which requires a new major version it would be better to first merge and release the v3.2.0: https://github.com/PrestaShop/ps_linklist/pull/91