### PR TITLE
Hide title block if grid name is null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     "exclude-from-classmap": []
   },
   "config": {
-    "preferred-install": "dist",
-    "prepend-autoloader": false
+    "preferred-install": "dist"
   },
   "type": "prestashop-module"
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "exclude-from-classmap": []
   },
   "config": {
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "prepend-autoloader": false
   },
   "type": "prestashop-module"
 }

--- a/views/PrestaShop/Admin/Common/Grid/grid_panel.html.twig
+++ b/views/PrestaShop/Admin/Common/Grid/grid_panel.html.twig
@@ -18,16 +18,20 @@
  *#}
 <div class="card js-grid-panel" id="{{ grid.id }}_grid_panel" data-hook-name="{{ grid.name|split(' ')|first }}">
   {% block grid_panel_header %}
-    <div class="card-header js-grid-header">
-      <h3 class="d-inline-block card-header-title">
-        {{ grid.name }} ({{ grid.data.records_total }})
-      </h3>
-      {% block grid_actions_block %}
-        <div class="d-inline-block float-right">
-          {{ include('@PrestaShop/Admin/Common/Grid/Blocks/grid_actions.html.twig', {'grid': grid}) }}
-        </div>
-      {% endblock %}
-    </div>
+    {% if grid.name is not null or grid.actions.grid|length > 0 %}
+      <div class="card-header js-grid-header">
+        {% if grid.name is not null %}
+          <h3 class="d-inline-block card-header-title">
+            {{ grid.name }} ({{ grid.data.records_total }})
+          </h3>
+        {% endif %}
+        {% block grid_actions_block %}
+          <div class="d-inline-block float-right">
+            {{ include('@PrestaShop/Admin/Common/Grid/Blocks/grid_actions.html.twig', {'grid': grid}) }}
+          </div>
+        {% endblock %}
+      </div>
+    {% endif %}
   {% endblock %}
 
   {% block grid_panel_body %}

--- a/views/PrestaShop/Admin/Common/Grid/grid_panel.html.twig
+++ b/views/PrestaShop/Admin/Common/Grid/grid_panel.html.twig
@@ -24,19 +24,17 @@
 <div class="card js-grid-panel" id="{{ grid.id }}_grid_panel" data-hook-name="{{ grid.name|split(' ')|first }}">
   {% block grid_panel_header %}
       {% if displayName is not sameas(false) %}
-      <div class="card-header js-grid-header">
-          {% if displayName is not sameas(false) %}
-          <h3 class="d-inline-block card-header-title">
-            {{ grid.name }} ({{ grid.data.records_total }})
-          </h3>
-        {% endif %}
-        {% block grid_actions_block %}
-          <div class="d-inline-block float-right">
-            {{ include('@PrestaShop/Admin/Common/Grid/Blocks/grid_actions.html.twig', {'grid': grid}) }}
+          <div class="card-header js-grid-header">
+            <h3 class="d-inline-block card-header-title">
+              {{ grid.name }} ({{ grid.data.records_total }})
+            </h3>
+            {% block grid_actions_block %}
+              <div class="d-inline-block float-right">
+                {{ include('@PrestaShop/Admin/Common/Grid/Blocks/grid_actions.html.twig', {'grid': grid}) }}
+              </div>
+            {% endblock %}
           </div>
-        {% endblock %}
-      </div>
-    {% endif %}
+      {% endif %}
   {% endblock %}
 
   {% block grid_panel_body %}

--- a/views/PrestaShop/Admin/Common/Grid/grid_panel.html.twig
+++ b/views/PrestaShop/Admin/Common/Grid/grid_panel.html.twig
@@ -16,11 +16,16 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
+{% set displayName = true %}
+{% if (grid.view_options.display_name is defined) %}
+    {% set displayName = grid.view_options.display_name %}
+{% endif %}
+
 <div class="card js-grid-panel" id="{{ grid.id }}_grid_panel" data-hook-name="{{ grid.name|split(' ')|first }}">
   {% block grid_panel_header %}
-    {% if grid.name is not null or grid.actions.grid|length > 0 %}
+      {% if displayName is not sameas(false) %}
       <div class="card-header js-grid-header">
-        {% if grid.name is not null %}
+          {% if displayName is not sameas(false) %}
           <h3 class="d-inline-block card-header-title">
             {{ grid.name }} ({{ grid.data.records_total }})
           </h3>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Hide table title if grid name is null.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes PrestaShop/Prestashop#17847
| How to test?  | Can be tested with https://github.com/PrestaShop/PrestaShop/pull/20261

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
