### PR TITLE
Prepare data for required fields

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -58,6 +58,7 @@ services:
       $moduleRepository: '@prestashop.core.admin.module.repository'
       $languages: '@=service("prestashop.adapter.legacy.context").getLanguages(true, service("prestashop.adapter.shop.context").getContextShopID())'
       $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID()'
+      $configuration: '@prestashop.adapter.legacy.configuration'
 
   # Form choices providers
   prestashop.module.link_block.choice_provider.hook:

--- a/src/Controller/Admin/Improve/Design/LinkBlockController.php
+++ b/src/Controller/Admin/Improve/Design/LinkBlockController.php
@@ -248,7 +248,7 @@ class LinkBlockController extends FrameworkBundleAdminController
         $formHandler = $this->get('prestashop.module.link_block.form_handler');
         $form = $formHandler->getForm();
         $form->handleRequest($request);
-
+        
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
                 $saveErrors = $formHandler->save($form->getData());
@@ -256,6 +256,8 @@ class LinkBlockController extends FrameworkBundleAdminController
                     $this->addFlash('success', $this->trans($successMessage, 'Admin.Notifications.Success'));
                     return $this->redirectToRoute('admin_link_block_list');
                 }
+
+                $this->flashErrors($saveErrors);
             }
             $formErrors = [];
             foreach ($form->getErrors(true) as $error) {

--- a/src/Form/LinkBlockFormDataProvider.php
+++ b/src/Form/LinkBlockFormDataProvider.php
@@ -146,9 +146,11 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
     {
         $defaultLanguageId = (int) $this->configuration->get('PS_LANG_DEFAULT');
 
-        foreach ($this->languages as $language) {
-            if (empty($linkBlock['block_name'][$language['id_lang']])) {
-                $linkBlock['block_name'][$language['id_lang']] = $linkBlock['block_name'][$defaultLanguageId];
+        if (!empty($linkBlock['block_name'])) {
+            foreach ($this->languages as $language) {
+                if (empty($linkBlock['block_name'][$language['id_lang']])) {
+                    $linkBlock['block_name'][$language['id_lang']] = $linkBlock['block_name'][$defaultLanguageId];
+                }
             }
         }
 

--- a/src/Form/LinkBlockFormDataProvider.php
+++ b/src/Form/LinkBlockFormDataProvider.php
@@ -22,6 +22,7 @@ namespace PrestaShop\Module\LinkList\Form;
 
 use Hook;
 use Ps_Linklist;
+use Language;
 use PrestaShop\Module\LinkList\Model\LinkBlock;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\Module\LinkList\Cache\LinkBlockCacheInterface;
@@ -277,25 +278,16 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
             if ($this->isEmptyCustom($custom)) {
                 continue;
             }
-            foreach ($this->languages as $language) {
-                if (!isset($custom[$language['id_lang']])) {
+
+            $defaultLanguageId = (int) $this->configuration->get('PS_LANG_DEFAULT');
+            $fields = ['title', 'url'];
+            foreach ($fields as $field) {
+                if (empty($custom[$defaultLanguageId][$field])) {
                     $errors[] = [
-                        'key' => 'Missing block_name value for language %s',
+                        'key' => 'Missing %s value in custom[%s] for language %s',
                         'domain' => 'Admin.Catalog.Notification',
-                        'parameters' => [$language['iso_code']],
+                        'parameters' => [$field, $customIndex, Language::getIsoById($defaultLanguageId)],
                     ];
-                } else {
-                    $langCustom = $custom[$language['id_lang']];
-                    $fields = ['title', 'url'];
-                    foreach ($fields as $field) {
-                        if (empty($langCustom[$field])) {
-                            $errors[] = [
-                                'key' => 'Missing %s value in custom[%s] for language %s',
-                                'domain' => 'Admin.Catalog.Notification',
-                                'parameters' => [$field, $customIndex, $language['iso_code']],
-                            ];
-                        }
-                    }
                 }
             }
         }

--- a/src/Form/LinkBlockFormDataProvider.php
+++ b/src/Form/LinkBlockFormDataProvider.php
@@ -162,8 +162,8 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
 
                 foreach ($customLanguages as $idLang => $custom) {
                     $linkBlock['custom'][$key][$idLang] = [
-                        'title' => !empty($custom['title']) ? $custom['title'] : $customLanguages[$defaultLanguageId]['title'],
-                        'url' => !empty($custom['url']) ? $custom['url'] : $customLanguages[$defaultLanguageId]['url'],
+                        'title' => $custom['title'] ?? $customLanguages[$defaultLanguageId]['title'],
+                        'url' => $custom['url'] ?? $customLanguages[$defaultLanguageId]['url'],
                     ];
                 }
             }

--- a/src/Form/LinkBlockFormDataProvider.php
+++ b/src/Form/LinkBlockFormDataProvider.php
@@ -159,7 +159,7 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
                 }
 
                 foreach ($customLanguages as $idLang => $custom) {
-                        $linkBlock['custom'][$key][$idLang] = [
+                    $linkBlock['custom'][$key][$idLang] = [
                         'title' => !empty($custom['title']) ? $custom['title'] : $customLanguages[$defaultLanguageId]['title'],
                         'url' => !empty($custom['url']) ? $custom['url'] : $customLanguages[$defaultLanguageId]['url'],
                     ];

--- a/src/Form/LinkBlockFormDataProvider.php
+++ b/src/Form/LinkBlockFormDataProvider.php
@@ -20,13 +20,14 @@
 
 namespace PrestaShop\Module\LinkList\Form;
 
-use PrestaShop\Module\LinkList\Cache\LinkBlockCacheInterface;
-use PrestaShop\Module\LinkList\Model\LinkBlock;
-use PrestaShop\Module\LinkList\Repository\LinkBlockRepository;
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
-use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use Hook;
 use Ps_Linklist;
+use PrestaShop\Module\LinkList\Model\LinkBlock;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\Module\LinkList\Cache\LinkBlockCacheInterface;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShop\Module\LinkList\Repository\LinkBlockRepository;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 
 /**
  * Class LinkBlockFormDataProvider.
@@ -64,6 +65,11 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
     private $shopId;
 
     /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
      * LinkBlockFormDataProvider constructor.
      *
      * @param LinkBlockRepository $repository
@@ -77,13 +83,15 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
         LinkBlockCacheInterface $cache,
         ModuleRepository $moduleRepository,
         array $languages,
-        $shopId
+        $shopId,
+        Configuration $configuration
     ) {
         $this->repository = $repository;
         $this->cache = $cache;
         $this->moduleRepository = $moduleRepository;
         $this->languages = $languages;
         $this->shopId = $shopId;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -136,7 +144,7 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
      */
     public function prepareData(array $linkBlock): array
     {
-        $defaultLanguageId = (int) \Configuration::get('PS_LANG_DEFAULT');
+        $defaultLanguageId = (int) $this->configuration->get('PS_LANG_DEFAULT');
 
         foreach ($this->languages as $language) {
             if (empty($linkBlock['block_name'][$language['id_lang']])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Details here: https://github.com/PrestaShop/PrestaShop/issues/22755 - behavior identical as one available in `ObjectModel` for years
| Type?         | improvement
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#22755
| How to test?  | Follow https://github.com/PrestaShop/PrestaShop/issues/22755
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**:notebook: BC Breaks :**
* In `src/Form/LinkBlockFormDataProvider.php`, the constructor has one new parameter, 6th parameter is now `Configuration $configuration`
