### PR TITLE
Remove invalid private field already present as protected in parent class

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_linklist</name>
     <displayName><![CDATA[Link List]]></displayName>
-    <version><![CDATA[4.0.0]]></version>
+    <version><![CDATA[4.0.1]]></version>
     <description><![CDATA[Adds a block with several links.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -73,7 +73,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $this->name = 'ps_linklist';
         $this->author = 'PrestaShop';
-        $this->version = '4.0.0';
+        $this->version = '4.0.1';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
 

--- a/src/Form/Type/LinkBlockType.php
+++ b/src/Form/Type/LinkBlockType.php
@@ -34,11 +34,6 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 class LinkBlockType extends TranslatorAwareType
 {
     /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
      * @var array
      */
     private $hookChoices;
@@ -89,7 +84,6 @@ class LinkBlockType extends TranslatorAwareType
         $this->productPageChoices = $productPageChoices;
         $this->staticPageChoices = $staticPageChoices;
         $this->categoryChoices = $categoryChoices;
-        $this->translator = $translator;
     }
 
     /**
@@ -110,7 +104,7 @@ class LinkBlockType extends TranslatorAwareType
                     'constraints' => [
                         new Length([
                             'max' => 40,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'Name of the block cannot be longer than %limit% characters',
                                 [
                                     '%limit%' => 40


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove invalid private field already present as protected in parent class
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
