### PR TITLE
Fix "Link widget" menu item not translated automatically

### DIFF
--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -88,6 +88,8 @@ class Ps_Linklist extends Module implements WidgetInterface
                 'visible' => true,
                 'name' => $tabNames,
                 'parent_class_name' => 'AdminParentThemes',
+                'wording' => 'Link Widget',
+                'wording_domain' => 'Modules.Linklist.Admin',
             ],
         ];
 

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -79,7 +79,7 @@ class Ps_Linklist extends Module implements WidgetInterface
 
         $tabNames = [];
         foreach (Language::getLanguages(true) as $lang) {
-            $tabNames[$lang['locale']] = $this->trans('Link List', array(), 'Modules.Linklist.Admin', $lang['locale']);
+            $tabNames[$lang['locale']] = $this->trans('Link Widget', array(), 'Modules.Linklist.Admin', $lang['locale']);
         }
         $this->tabs = [
             [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add wording and wording domain to the menu tab so that it is auto translated. <br> ⚠️ **WARNING:** Requires [this PR](https://github.com/PrestaShop/PrestaShop/pull/18082) to work!
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/24010
| How to test?  | Install shop in a language other than English, or install a non-english language package. The "Link Widget" menu item (under Customize > Appearance) is translated accordingly.

After a clean install in French, you get this:

<img width="217" alt="Screenshot 2021-04-08 at 15 14 37" src="https://user-images.githubusercontent.com/1009343/114033077-399f3080-987d-11eb-8855-a3e041832deb.png">

This auto translation works only in 1.7.8. But the module should be installable in 1.7.7 as well.
