### PR TITLE
Fix widgets count - Do not group by when counting

### DIFF
--- a/src/Core/Grid/Query/LinkBlockQueryBuilder.php
+++ b/src/Core/Grid/Query/LinkBlockQueryBuilder.php
@@ -48,6 +48,7 @@ final class LinkBlockQueryBuilder extends AbstractDoctrineQueryBuilder
             lbs.position as position,
             GROUP_CONCAT(s.name SEPARATOR ", ") as shop_name
             ')
+            ->groupBy('lb.id_link_block')
             ->orderBy(
                 $searchCriteria->getOrderBy(),
                 $searchCriteria->getOrderWay()
@@ -92,8 +93,7 @@ final class LinkBlockQueryBuilder extends AbstractDoctrineQueryBuilder
             ->innerJoin('lb', $this->dbPrefix . 'link_block_lang', 'lbl', 'lb.id_link_block = lbl.id_link_block')
             ->leftJoin('lb', $this->dbPrefix . 'link_block_shop', 'lbs', 'lb.id_link_block = lbs.id_link_block')
             ->leftJoin('lb', $this->dbPrefix . 'hook', 'h', 'lb.id_hook = h.id_hook')
-            ->leftJoin('lb', $this->dbPrefix . 'shop', 's', 's.id_shop = lbs.id_shop')
-            ->groupBy('lb.id_link_block');
+            ->leftJoin('lb', $this->dbPrefix . 'shop', 's', 's.id_shop = lbs.id_shop');
 
         foreach ($filters as $name => $value) {
             if ('id_lang' === $name) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When building query for widgets count, if we group by id_link_block, we will have one line per widget with a count of 1. That's why we don't have to group when counting widgets
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Install Prestashop > Go to modules and hit on 'Configure' ps_linklist > You will have the list of widgets.<br>Before this PR, you will have a count of 1 no matter the number of widgets.<br>With this PR, you'll have the good number

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
