### PR TITLE
Replace `!defined('_CAN_LOAD_FILES_')` by `!defined('_PS_VERSION_')`

### DIFF
--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -17,7 +17,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
-if (!defined('_CAN_LOAD_FILES_')) {
+if (!defined('_PS_VERSION_')) {
     exit;
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Replace `!defined('_CAN_LOAD_FILES_')` by `!defined('_PS_VERSION_')` . I have no idea what `_CAN_LOAD_FILES_` is but the [recommended practice](https://devdocs.prestashop.com/1.7/modules/creation/) is `_PS_VERSION_`
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
