### PR TITLE
Make ps_linklist compatible with twig 3

### DIFF
--- a/views/templates/admin/fields.html.twig
+++ b/views/templates/admin/fields.html.twig
@@ -65,7 +65,7 @@
 {%- endblock checkbox_widget %}
 
 {% block form_row -%}
-    {% spaceless %}
+    {% apply spaceless %}
         <div class="{{ block('form_row_class') }} {% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
             {% if form.vars.label is not same as(false) %}
                 {{ form_label(form) }}
@@ -78,7 +78,7 @@
                 {{ form_errors(form) }}
             </div>
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {%- endblock form_row %}
 
 {% block form_row_class -%}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `spaceless` has been deprecated in twig 2 & removed in twig 3. We should use `apply spaceless` instead which is compatible twig >= 1.40
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | We can only test that there is no regression for now, so navigate on ps_linklist admin pages and see that everything is working

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
