### PR TITLE
Remove optional parameter before required parameter

### DIFF
--- a/src/Repository/LinkBlockRepository.php
+++ b/src/Repository/LinkBlockRepository.php
@@ -458,7 +458,7 @@ class LinkBlockRepository
      *
      * @throws DatabaseException
      */
-    private function updateMaxPosition(int $linkBlockId, ?int $hookId = null, array $shopIds): void
+    private function updateMaxPosition(int $linkBlockId, ?int $hookId, array $shopIds): void
     {
         $qb = $this->connection->createQueryBuilder();
         foreach ($shopIds as $shopId) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | declaring a function with an optional parameter before a required parameter is deprecated in PHP 8.1, this PR aims to fix this deprecation.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Nothing should have changed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
