### PR TITLE
Fix upgrade when comming from an 1.6 shop

### DIFF
--- a/upgrade/upgrade-5.0.php
+++ b/upgrade/upgrade-5.0.php
@@ -25,8 +25,10 @@ function upgrade_module_5_0()
 {
     $result = true;
     $result &= Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'link_block_shop`  ADD COLUMN `position` int(10) unsigned NOT NULL DEFAULT 0');
+    // Delete blockcms data that are not used in previous version of this module
+    $result &=Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'link_block_shop`');
 
-    foreach (Shop::getContextListShopID() as $shopId) {
+    foreach (Shop::getShops(true, null, true) as $shopId) {
         $result &= Db::getInstance()->execute(
             'INSERT INTO `' . _DB_PREFIX_ . 'link_block_shop` (`id_link_block`, `position`, `id_shop`)
             SELECT `id_link_block`, `position`, ' . $shopId . ' FROM `' . _DB_PREFIX_ . 'link_block`


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If you had blockcms installed, during the migration to ps_linklist, the table `ps_link_block_shop` gets filled (even though it's not used) leading to a duplicate key error when upgrading to v5. This PR aims to solve this issue by deleting the not-used entries in `ps_link_block_shop` before filling it. It also populates the `ps_link_block_shop` for every active shop and not only those in the current shop context as the upgrade of the module is not shop-dependent.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | As this issue happens during upgrade, using addons API, it cannot be tested easily, there is a way to simulate it though:<ol><li>Install a 1.7.8.0 shop</li><li>Uninstall the module `ps_linklist` (and delete the files)</li><li>Install the version 4.0.0 of `ps_linklist`</li><li>Insert a new entry in the table `ps_link_block_shop` (```INSERT INTO `ps_link_block_shop` (`id_link_block`, `id_shop`) VALUES ('1', '1');```)</li><li>Install the module with this PR: No error should happens</li></ol>

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
