### PR TITLE
Add the production mode to the build command

### DIFF
--- a/views/package.json
+++ b/views/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.4",
   "description": "",
   "scripts": {
-    "build": "webpack --progress --stats-error-details",
+    "build": "webpack --progress --stats-error-details --mode=production",
     "watch": "webpack --progress --watch --mode=development"
   },
   "author": "PrestaShop",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR just set the production mode explicitly while running the build command.
| Type?         | improvement 
| BC breaks?    |no
| Deprecation? | no
| Fixed ticket? | nothing
| How to test?  | run `npm install & npm run build` in views folder.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
