### PR TITLE
Hide Best Sales link if feature is disabled

### DIFF
--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -26,6 +26,8 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 use PrestaShop\Module\LinkList\DataMigration;
+use PrestaShop\Module\LinkList\Filter\BestSalesRouteFilter;
+use PrestaShop\Module\LinkList\Filter\LinkFilter;
 use PrestaShop\Module\LinkList\LegacyLinkBlockRepository;
 use PrestaShop\Module\LinkList\Model\LinkBlockLang;
 use PrestaShop\Module\LinkList\Presenter\LinkBlockPresenter;
@@ -101,7 +103,13 @@ class Ps_Linklist extends Module implements WidgetInterface
         $this->templateFile = 'module:ps_linklist/views/templates/hook/linkblock.tpl';
         $this->templateFileColumn = 'module:ps_linklist/views/templates/hook/linkblock-column.tpl';
 
-        $this->linkBlockPresenter = new LinkBlockPresenter(new Link(), $this->context->language);
+        $this->linkBlockPresenter = new LinkBlockPresenter(
+            new Link(),
+            $this->context->language,
+            new LinkFilter([
+                new BestSalesRouteFilter(),
+            ])
+        );
         $this->legacyBlockRepository = new LegacyLinkBlockRepository(Db::getInstance(), $this->context->shop, $this->context->getTranslator());
     }
 
@@ -131,10 +139,12 @@ class Ps_Linklist extends Module implements WidgetInterface
         } else {
             $dataLoadedWithSuccess = $this->installFixtures();
         }
-
-        if ($dataLoadedWithSuccess
+        $dataLoadedWithSuccess = $dataLoadedWithSuccess
             && $this->registerHook('displayFooter')
-            && $this->registerHook('actionUpdateLangAfter')) {
+            && $this->registerHook('actionUpdateLangAfter')
+            && $this->registerHook('actionGeneralPageSave')
+        ;
+        if ($dataLoadedWithSuccess) {
             return true;
         }
 
@@ -224,10 +234,17 @@ class Ps_Linklist extends Module implements WidgetInterface
         }
     }
 
+    public function hookActionGeneralPageSave()
+    {
+        $this->_clearCache('');
+    }
+
     public function _clearCache($template, $cache_id = null, $compile_id = null)
     {
-        parent::_clearCache($this->templateFile);
-        parent::_clearCache($this->templateFileColumn);
+        return array_sum([
+            parent::_clearCache($this->templateFile),
+            parent::_clearCache($this->templateFileColumn),
+        ]);
     }
 
     public function getContent()

--- a/src/Filter/BestSalesRouteFilter.php
+++ b/src/Filter/BestSalesRouteFilter.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\LinkList\Filter;
+
+use Configuration;
+
+class BestSalesRouteFilter implements RouteFilterInterface
+{
+    public function supports(string $routeId): bool
+    {
+        return 'best-sales' === $routeId;
+    }
+
+    public function isRouteEnabled(string $routeId): bool
+    {
+        return (bool) Configuration::get('PS_DISPLAY_BEST_SELLERS');
+    }
+}

--- a/src/Filter/LinkFilter.php
+++ b/src/Filter/LinkFilter.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\LinkList\Filter;
+
+class LinkFilter
+{
+    /**
+     * @var RouteFilterInterface[]
+     */
+    private $routeFilters = [];
+
+    public function __construct(array $routeFilters = [])
+    {
+        $this->addRouteFilter(...$routeFilters);
+    }
+
+    public function addRouteFilter(RouteFilterInterface ...$routeFilters): void
+    {
+        foreach ($routeFilters as $routeFilter) {
+            $this->routeFilters[] = $routeFilter;
+        }
+    }
+
+    public function isRouteEnabled(string $routeId): bool
+    {
+        foreach ($this->routeFilters as $filter) {
+            if ($filter->supports($routeId) && !$filter->isRouteEnabled($routeId)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Filter/RouteFilterInterface.php
+++ b/src/Filter/RouteFilterInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\LinkList\Filter;
+
+interface RouteFilterInterface
+{
+    public function supports(string $routeId): bool;
+
+    public function isRouteEnabled(string $routeId): bool;
+}

--- a/src/Filter/index.php
+++ b/src/Filter/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Presenter/LinkBlockPresenter.php
+++ b/src/Presenter/LinkBlockPresenter.php
@@ -22,6 +22,7 @@
 namespace PrestaShop\Module\LinkList\Presenter;
 
 use Meta;
+use PrestaShop\Module\LinkList\Filter\LinkFilter;
 use PrestaShop\Module\LinkList\Model\LinkBlock;
 use Tools;
 
@@ -32,6 +33,7 @@ class LinkBlockPresenter
 {
     private $link;
     private $language;
+    private $linkFilter;
 
     /**
      * LinkBlockPresenter constructor.
@@ -39,10 +41,11 @@ class LinkBlockPresenter
      * @param \Link $link
      * @param \Language $language
      */
-    public function __construct(\Link $link, \Language $language)
+    public function __construct(\Link $link, \Language $language, LinkFilter $linkFilter = null)
     {
         $this->link = $link;
         $this->language = $language;
+        $this->linkFilter = $linkFilter ?? new LinkFilter();
     }
 
     /**
@@ -156,7 +159,7 @@ class LinkBlockPresenter
     {
         $productLinks = [];
         foreach ($productIds as $productId) {
-            if (false === $productId) {
+            if (false === $productId || $this->isLinkDisabled($productId)) {
                 continue;
             }
 
@@ -182,7 +185,7 @@ class LinkBlockPresenter
     {
         $staticLinks = [];
         foreach ($staticIds as $staticId) {
-            if (false === $staticId) {
+            if (false === $staticId || $this->isLinkDisabled($staticId)) {
                 continue;
             }
 
@@ -253,5 +256,10 @@ class LinkBlockPresenter
         }
 
         return $categoryLinks;
+    }
+
+    private function isLinkDisabled(string $routeId): bool
+    {
+        return !$this->linkFilter->isRouteEnabled($routeId);
     }
 }

--- a/upgrade/upgrade-5.0.5.php
+++ b/upgrade/upgrade-5.0.5.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_5_0_5($object)
+{
+    return $object->registerHook('actionGeneralPageSave');
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | A new filter component hides the "Best Sales" link in FO only if the feature is disabled in global configuration. This filter can process more static links if required later.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#18028.
| How to test?  | In BO disable the "Best Sales" feature in global configuration.<br/>In FO the link should be hidden in footer.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
