### PR TITLE
Update LinkBlockRepository.php

### DIFF
--- a/src/Repository/LinkBlockRepository.php
+++ b/src/Repository/LinkBlockRepository.php
@@ -25,6 +25,7 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Hook;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\Module\LinkList\Adapter\ObjectModelHandler;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Exception\DatabaseException;


### PR DESCRIPTION
Trying to deactivate the 'Shops' link in the footer resulted in an error, which suggested a use of PrestaShop\PrestaShop\Adapter\Tools could be missing, Adding this use solved the error
Type: bug fix

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Trying to deactivate the 'Shops' link in the footer resulted in an error, which suggested a use of PrestaShop\PrestaShop\Adapter\Tools could be missing, Adding this use solved the error
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
