### PR TITLE
Fixing deprecated for PHP 8.1

### DIFF
--- a/src/Model/LinkBlock.php
+++ b/src/Model/LinkBlock.php
@@ -84,7 +84,7 @@ class LinkBlock extends \ObjectModel
             if ($this->custom_content) {
                 $this->custom_content = array_map(
                     function ($el) {
-                        return json_decode($el, true);
+                        return json_decode($el ?? '', true);
                     },
                     $this->custom_content
                 );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PHP 8.1, `json_decode()` deprecates passing `null` as its first argument. This PR aims to check if the first argument is `null` and fallback to an empty string if that is the case.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#28633
| How to test?  | Please see PrestaShop/PrestaShop#28633

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
