### PR TITLE
When transplanted on left column of product page, this module wasn't …

### DIFF
--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -261,7 +261,9 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $key = 'ps_linklist|' . $hookName;
 
-        if ($hookName === 'displayLeftColumn' || $hookName === 'displayRightColumn') {
+        if (   $hookName === 'displayLeftColumn' 
+            || $hookName === 'displayLeftColumnProduct' 
+            || $hookName === 'displayRightColumn') {
             $template = $this->templateFileColumn;
         } else {
             $template = $this->templateFile;


### PR DESCRIPTION
…rendered with the column template.

I added a test on displayLeftColumnProduct to solve this.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When transplanted on left column of product page, this module wasn't rendered with the column template.
|                      | I added a test on displayLeftColumnProduct to solve this. Prestashop 1.7.8.7 Theme Classic 1.0.0 
|                      | ps_linklist 5.0.5
| Type?            | bug fix / improvement
| BC breaks?    | (what is BC ?)
| Deprecations? | no
| Fixed ticket? | I didn't find any ticket about this.
| How to test?  | transplant a linklist on displayLeftColumnProduct hook and navigate to product page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
