### PR TITLE
Add registration page to available links

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -117,6 +117,7 @@ services:
         - 'sitemap'
         - 'stores'
         - 'authentication'
+        - 'registration'
         - 'my-account'
 
   # Form types


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adds new registration page to available links.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/pull/27755/#issuecomment-1279942207
| How to test?  | Try to edit link block and see that you can now add registration page.

cc @Caleydon

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
