### PR TITLE
Replaces deprecated `setHookDispatcher` method

### DIFF
--- a/src/Core/Grid/Definition/Factory/LinkBlockDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LinkBlockDefinitionFactory.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
 
 /**
@@ -55,8 +56,10 @@ final class LinkBlockDefinitionFactory extends AbstractGridDefinitionFactory
      */
     public function __construct(
         array $hook,
-        MultistoreContextCheckerInterface $multistoreContextChecker
+        MultistoreContextCheckerInterface $multistoreContextChecker,
+        HookDispatcherInterface $hookDispatcher
     ) {
+        parent::__construct($hookDispatcher);
         $this->hook = $hook;
         $this->multistoreContextChecker = $multistoreContextChecker;
     }
@@ -85,48 +88,48 @@ final class LinkBlockDefinitionFactory extends AbstractGridDefinitionFactory
         $columns = (new ColumnCollection())
             ->add(
                 (new DataColumn('id_link_block'))
-                ->setName($this->trans('ID', [], 'Modules.Linklist.Admin'))
-                ->setOptions([
-                    'field' => 'id_link_block',
-                ])
+                    ->setName($this->trans('ID', [], 'Modules.Linklist.Admin'))
+                    ->setOptions([
+                        'field' => 'id_link_block',
+                    ])
             )
             ->add(
                 (new DataColumn('block_name'))
-                ->setName($this->trans('Name of the block', [], 'Modules.Linklist.Admin'))
-                ->setOptions([
-                    'field' => 'block_name',
-                ])
+                    ->setName($this->trans('Name of the block', [], 'Modules.Linklist.Admin'))
+                    ->setOptions([
+                        'field' => 'block_name',
+                    ])
             )
             ->add(
                 (new ActionColumn('actions'))
-                ->setOptions([
-                    'actions' => (new RowActionCollection())
-                        ->add(
-                            (new LinkRowAction('edit'))
-                            ->setIcon('edit')
-                            ->setOptions([
-                                'route' => 'admin_link_block_edit',
-                                'route_param_name' => 'linkBlockId',
-                                'route_param_field' => 'id_link_block',
-                            ])
-                        )
-                        ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'POST',
-                                'route' => 'admin_link_block_delete',
-                                'route_param_name' => 'linkBlockId',
-                                'route_param_field' => 'id_link_block',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
-                        ),
-                ])
+                    ->setOptions([
+                        'actions' => (new RowActionCollection())
+                            ->add(
+                                (new LinkRowAction('edit'))
+                                    ->setIcon('edit')
+                                    ->setOptions([
+                                        'route' => 'admin_link_block_edit',
+                                        'route_param_name' => 'linkBlockId',
+                                        'route_param_field' => 'id_link_block',
+                                    ])
+                            )
+                            ->add(
+                                (new SubmitRowAction('delete'))
+                                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
+                                    ->setIcon('delete')
+                                    ->setOptions([
+                                        'method' => 'POST',
+                                        'route' => 'admin_link_block_delete',
+                                        'route_param_name' => 'linkBlockId',
+                                        'route_param_field' => 'id_link_block',
+                                        'confirm_message' => $this->trans(
+                                            'Delete selected item?',
+                                            [],
+                                            'Admin.Notifications.Warning'
+                                        ),
+                                    ])
+                            ),
+                    ])
             )
         ;
 
@@ -134,16 +137,16 @@ final class LinkBlockDefinitionFactory extends AbstractGridDefinitionFactory
             $columns->addBefore(
                 'actions',
                 (new PositionColumn('position'))
-                ->setName($this->trans('Position', [], 'Admin.Global'))
-                ->setOptions([
-                    'id_field' => 'id_link_block',
-                    'position_field' => 'position',
-                    'update_route' => 'admin_link_block_update_positions',
-                    'update_method' => 'POST',
-                    'record_route_params' => [
-                        'id_hook' => 'hookId',
-                    ],
-                ])
+                    ->setName($this->trans('Position', [], 'Admin.Global'))
+                    ->setOptions([
+                        'id_field' => 'id_link_block',
+                        'position_field' => 'position',
+                        'update_route' => 'admin_link_block_update_positions',
+                        'update_method' => 'POST',
+                        'record_route_params' => [
+                            'id_hook' => 'hookId',
+                        ],
+                    ])
             );
         } else {
             $columns->addBefore(

--- a/src/Core/Grid/LinkBlockGridFactory.php
+++ b/src/Core/Grid/LinkBlockGridFactory.php
@@ -116,14 +116,14 @@ final class LinkBlockGridFactory
      */
     private function buildGridFactoryByHook(array $hook)
     {
-        $definitionFactory = new LinkBlockDefinitionFactory($hook, $this->shopContext);
+        $definitionFactory = new LinkBlockDefinitionFactory($hook, $this->shopContext, $this->hookDispatcher);
         $definitionFactory->setTranslator($this->translator);
-        $definitionFactory->setHookDispatcher($this->hookDispatcher);
 
         return new GridFactory(
             $definitionFactory,
             $this->dataFactory,
-            $this->filterFormFactory
+            $this->filterFormFactory,
+            $this->hookDispatcher
         );
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Replaces deprecated `setHookDispatcher` method
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/32178.
| How to test?  | See ticket.
