### PR TITLE
Revert controller service

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_linklist</name>
     <displayName><![CDATA[Link List]]></displayName>
-    <version><![CDATA[6.0.2]]></version>
+    <version><![CDATA[6.0.3]]></version>
     <description><![CDATA[Adds a block with several links.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/config/services.yml
+++ b/config/services.yml
@@ -167,6 +167,3 @@ services:
       - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
     tags:
       - { name: form.type }
-
-  PrestaShop\Module\LinkList\Controller\Admin\Improve\Design\LinkBlockController:
-    autowire: true

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -73,7 +73,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $this->name = 'ps_linklist';
         $this->author = 'PrestaShop';
-        $this->version = '6.0.2';
+        $this->version = '6.0.3';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This change was tested along with the recent PR https://github.com/PrestaShop/PrestaShop/pull/32450 Thanks to the changes made in this PR and the effort for retro compatibility, the modules don't need to forcibly define their controllers as services to be compatible with v9 (as long as they extend `FrameworkBundleAdminController`)
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Test that with this modif the module still works with 8.1 although since this PR is a revert from https://github.com/PrestaShop/ps_linklist/pull/171 and the module worked fine before it shouldn't be a problem It should also work with the `develop` branch (once https://github.com/PrestaShop/PrestaShop/pull/32450 is merged)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
