### PR TITLE
Fix - Category with duplicate name does not appear in module configur…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,12 @@
 
 Give more visibility to your content/static pages (CMS, external pages, or else), where you want and when you want, to make your visitors feel like shopping on your store.
 
-## Compatibility
-
-PrestaShop: `8.1.0` or later
-
 ## Multistore compatibility
 
 This module is compatible with the multistore :heavy_check_mark: <br/>
 It can be configured differently from one store to another.<br/>
 It can be configured quickly in the same way on all stores thanks to the all shops context or the group of shops.<br/>
 It can be activated on one store and deactivated on another
-
-## How to test
-
-Edit the existing linklist block and add custom contents
-CRUD a new linklist block
 
 ## Building assets
 

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -155,7 +155,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     /**
      * @return bool
      *
-     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\DBAL\DBALException
      */
     private function createTables()
     {
@@ -174,7 +174,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     /**
      * @return bool
      *
-     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\DBAL\DBALException
      */
     private function installFixtures()
     {

--- a/src/Adapter/index.php
+++ b/src/Adapter/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Form/ChoiceProvider/CategoryChoiceProvider.php
+++ b/src/Form/ChoiceProvider/CategoryChoiceProvider.php
@@ -47,7 +47,7 @@ final class CategoryChoiceProvider extends AbstractDatabaseChoiceProvider
         $categories = $qb->execute()->fetchAll();
         $choices = [];
         foreach ($categories as $category) {
-            $choices[$category['name']] = $category['id_category'];
+            $choices[$category['id_category'] . ' ' . $category['name']] = $category['id_category'];
         }
 
         return $choices;

--- a/src/Repository/LinkBlockRepository.php
+++ b/src/Repository/LinkBlockRepository.php
@@ -21,10 +21,9 @@
 namespace PrestaShop\Module\LinkList\Repository;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result;
 use Hook;
 use PrestaShop\Module\LinkList\Adapter\ObjectModelHandler;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
@@ -239,6 +238,8 @@ class LinkBlockRepository
 
     /**
      * @return array
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function createTables()
     {
@@ -270,11 +271,11 @@ class LinkBlockRepository
         ];
 
         foreach ($queries as $query) {
-            try {
-                $this->connection->executeQuery($query);
-            } catch (DBALException $e) {
+            $statement = $this->connection->executeQuery($query);
+
+            if ($statement instanceof Statement && 0 != (int) $statement->errorCode()) {
                 $errors[] = [
-                    'key' => json_encode($e->getMessage()),
+                    'key' => json_encode($statement->errorInfo()),
                     'parameters' => [],
                     'domain' => 'Admin.Modules.Notification',
                 ];
@@ -286,6 +287,8 @@ class LinkBlockRepository
 
     /**
      * @return array
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function installFixtures()
     {
@@ -313,12 +316,10 @@ class LinkBlockRepository
         }
 
         foreach ($queries as $query) {
-            $this->connection->executeQuery($query);
-            try {
-                $this->connection->executeQuery($query);
-            } catch (DBALException $e) {
+            $statement = $this->connection->executeQuery($query);
+            if ($statement instanceof Statement && 0 != (int) $statement->errorCode()) {
                 $errors[] = [
-                    'key' => json_encode($e->getMessage()),
+                    'key' => json_encode($statement->errorInfo()),
                     'parameters' => [],
                     'domain' => 'Admin.Modules.Notification',
                 ];
@@ -330,6 +331,8 @@ class LinkBlockRepository
 
     /**
      * @return array
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function dropTables()
     {
@@ -341,11 +344,10 @@ class LinkBlockRepository
         ];
         foreach ($tableNames as $tableName) {
             $sql = 'DROP TABLE IF EXISTS ' . $this->dbPrefix . $tableName;
-            try {
-                $this->connection->executeQuery($sql);
-            } catch (DBALException $e) {
+            $statement = $this->connection->executeQuery($sql);
+            if ($statement instanceof Statement && 0 != (int) $statement->errorCode()) {
                 $errors[] = [
-                    'key' => json_encode($e->getMessage()),
+                    'key' => json_encode($statement->errorInfo()),
                     'parameters' => [],
                     'domain' => 'Admin.Modules.Notification',
                 ];
@@ -413,16 +415,15 @@ class LinkBlockRepository
      * @param QueryBuilder $qb
      * @param string $errorPrefix
      *
-     * @return Result|int|string
+     * @return Statement|int
      *
      * @throws DatabaseException
      */
     private function executeQueryBuilder(QueryBuilder $qb, $errorPrefix = 'SQL error')
     {
-        try {
-            $statement = $qb->execute();
-        } catch (DBALException $e) {
-            throw new DatabaseException($errorPrefix . ': ' . var_export($e->getMessage(), true));
+        $statement = $qb->execute();
+        if ($statement instanceof Statement && !empty($statement->errorInfo())) {
+            throw new DatabaseException($errorPrefix . ': ' . var_export($statement->errorInfo(), true));
         }
 
         return $statement;
@@ -446,7 +447,7 @@ class LinkBlockRepository
             ->setParameter('idShop', $idShop)
         ;
 
-        $maxPosition = $qb->execute()->fetch(\PDO::FETCH_COLUMN);
+        $maxPosition = $qb->execute()->fetchColumn(0);
 
         return null !== $maxPosition ? $maxPosition + 1 : 0;
     }
@@ -499,9 +500,8 @@ class LinkBlockRepository
 
                 ++$i;
 
-                try {
-                    $qb->execute();
-                } catch (DBALException $e) {
+                $statement = $qb->execute();
+                if ($statement instanceof Statement && $statement->errorCode()) {
                     throw new DatabaseException('Could not update #%i');
                 }
             }


### PR DESCRIPTION
…ation

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Category with duplicate name does not appear in module configuration
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create two categories with the same name in PrestaShop. In the configuration of the ps_linklist module you will see that only one of them appears.
![Selección_439](https://github.com/PrestaShop/ps_linklist/assets/40068093/d92efa66-b754-4893-87ac-9f7de6eb1bb8)
![Selección_440](https://github.com/PrestaShop/ps_linklist/assets/40068093/01f1c9c8-e865-46ab-a2e5-77faa1b8249b)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
