### PR TITLE
Fix - Category with duplicate name does not appear in module configur…

### DIFF
--- a/src/Form/ChoiceProvider/CategoryChoiceProvider.php
+++ b/src/Form/ChoiceProvider/CategoryChoiceProvider.php
@@ -47,7 +47,7 @@ final class CategoryChoiceProvider extends AbstractDatabaseChoiceProvider
         $categories = $qb->execute()->fetchAll();
         $choices = [];
         foreach ($categories as $category) {
-            $choices[$category['name']] = $category['id_category'];
+            $choices[$category['id_category'] . ' ' . $category['name']] = $category['id_category'];
         }
 
         return $choices;


### PR DESCRIPTION
…ation

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Category with duplicate name does not appear in module configuration.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create two categories with the same name in PrestaShop. In the configuration of the ps_linklist module you will see that only one of them appears.
![Selección_439](https://github.com/PrestaShop/ps_linklist/assets/40068093/f9e61ea5-5811-4c64-9c17-1176618ee46e)
![Selección_440](https://github.com/PrestaShop/ps_linklist/assets/40068093/10f3c866-252a-425e-a664-6a09517105e0)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
