### PR TITLE
Fix: Can't access link blocks from BO with wrong language on employee

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -10,7 +10,7 @@ services:
     arguments:
       $connection: '@doctrine.dbal.default_connection'
       $dbPrefix: '%database_prefix%'
-      $languages: '@=service("prestashop.adapter.legacy.context").getLanguages(false, service("prestashop.adapter.shop.context").getContextShopID())'
+      $languages: '@=service("prestashop.adapter.legacy.context").getLanguages(false)'
       $translator: '@translator'
       $isMultiStoreUsed: '@=service("prestashop.adapter.feature.multistore").isUsed()'
       $multiStoreContext: '@prestashop.adapter.shop.context'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When edititing the blocks in ps_linklist, it's not possible to access the blocks in multistore of the language of the employee is not matching the language of the shop.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#35275.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
