### PR TITLE
Prevent duplicate error on install

### DIFF
--- a/src/Repository/LinkBlockRepository.php
+++ b/src/Repository/LinkBlockRepository.php
@@ -313,7 +313,6 @@ class LinkBlockRepository
         }
 
         foreach ($queries as $query) {
-            $this->connection->executeQuery($query);
             try {
                 $this->connection->executeQuery($query);
             } catch (DBALException $e) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove duplicate execution of the request to prevent duplicate errors from DB on install
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Run `composer create-test-db` on develop or 8.1.x branch from the core One time out of two the install fails because of a duplicate error from the DB, with this branch fix the problem is gone

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
