### PR TITLE
Fix grid count invalid with multiple languages

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_linklist</name>
     <displayName><![CDATA[Link List]]></displayName>
-    <version><![CDATA[6.0.6]]></version>
+    <version><![CDATA[6.0.7]]></version>
     <description><![CDATA[Adds a block with several links.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -73,7 +73,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $this->name = 'ps_linklist';
         $this->author = 'PrestaShop';
-        $this->version = '6.0.6';
+        $this->version = '6.0.7';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
 

--- a/src/Core/Grid/Query/LinkBlockQueryBuilder.php
+++ b/src/Core/Grid/Query/LinkBlockQueryBuilder.php
@@ -73,7 +73,7 @@ final class LinkBlockQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(lb.id_link_block)');
+        $qb->select('COUNT(DISTINCT(lb.id_link_block))');
 
         return $qb;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix grid builder count query, we must count DISTINCT IDs now because multilang data is returned by the query
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Go to Design > Link list, before this PR the count is doubled (well if you have two languages installed, if you have three it will likely be tripled, ...) ith the fix the count is correct regardless of the number of languages installed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
