### PR TITLE
Fix choices display when categories and cms categories got the same names

### DIFF
--- a/src/Form/ChoiceProvider/CMSCategoryChoiceProvider.php
+++ b/src/Form/ChoiceProvider/CMSCategoryChoiceProvider.php
@@ -47,7 +47,7 @@ final class CMSCategoryChoiceProvider extends AbstractDatabaseChoiceProvider
         $categories = $qb->execute()->fetchAll();
         $choices = [];
         foreach ($categories as $category) {
-            $choices[$category['name']] = $category['id_cms_category'];
+            $choices[$category['id_cms_category']] = sprintf('%s (%d)', $category['name'], $category['id_cms_category']);
         }
 
         return $choices;

--- a/src/Form/ChoiceProvider/CMSPageChoiceProvider.php
+++ b/src/Form/ChoiceProvider/CMSPageChoiceProvider.php
@@ -59,7 +59,7 @@ final class CMSPageChoiceProvider extends AbstractDatabaseChoiceProvider
     {
         $choices = [];
 
-        foreach ($this->categories as $categoryName => $categoryId) {
+        foreach ($this->categories as $categoryId => $categoryName) {
             $qb = $this->connection->createQueryBuilder();
             $qb
                 ->select('c.id_cms, cl.meta_title')
@@ -77,7 +77,7 @@ final class CMSPageChoiceProvider extends AbstractDatabaseChoiceProvider
             ;
             $pages = $qb->execute()->fetchAll();
             foreach ($pages as $page) {
-                $choices[$categoryName][$page['id_cms'] . ' ' . $page['meta_title']] = $page['id_cms'];
+                $choices[$categoryName][sprintf('%s (%d)', $page['meta_title'], $page['id_cms'])] = $page['id_cms'];
             }
         }
 

--- a/src/Form/Type/LinkBlockType.php
+++ b/src/Form/Type/LinkBlockType.php
@@ -151,7 +151,7 @@ class LinkBlockType extends TranslatorAwareType
                 'expanded' => true,
             ])
             ->add('category', ChoiceType::class, [
-                'choices' => $this->categoryChoices,
+                'choices' => array_flip($this->categoryChoices),
                 'label' => $this->trans('Categories', 'Modules.Linklist.Admin'),
                 'multiple' => true,
                 'expanded' => true,


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix choices display in the admin when the shop categories and cms categories have identical names
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create multiple categories (or cms categories) with the same names. It now works correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
