### PR TITLE
Make module compliant with PSV9

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,29 +3,20 @@ on: [push, pull_request]
 jobs:
   # Check there is no syntax errors in the project
   php-linter:
-    name: PHP Syntax check 7.2 => 8.2
+    name: PHP Syntax check 8.1 => 8.3
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
-
-      - name: PHP syntax checker 7.2
-        uses: prestashop/github-action-php-lint/7.2@master
-
-      - name: PHP syntax checker 7.3
-        uses: prestashop/github-action-php-lint/7.3@master
-
-      - name: PHP syntax checker 7.4
-        uses: prestashop/github-action-php-lint/7.4@master
-
-      - name: PHP syntax checker 8.0
-        uses: prestashop/github-action-php-lint/8.0@master
 
       - name: PHP syntax checker 8.1
         uses: prestashop/github-action-php-lint/8.1@master
 
       - name: PHP syntax checker 8.2
         uses: prestashop/github-action-php-lint/8.2@master
+
+      - name: PHP syntax checker 8.3
+        uses: prestashop/github-action-php-lint/8.3@master
 
   # Check the PHP code follow the coding standards
   php-cs-fixer:
@@ -35,7 +26,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
 
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -63,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
 
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -86,4 +77,4 @@ jobs:
 
       # Docker images prestashop/prestashop may be used, even if the shop remains uninstalled
       - name: Execute PHPStan on PrestaShop (Tag ${{ matrix.presta-versions }})
-        run: ./tests/phpstan.sh ${{ matrix.presta-versions }}
+        run: ./tests/phpstan.sh ${{ matrix.presta-versions }} --error-format=github

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 !vendor/index.php
 !vendor/.htaccess
 /.php_cs.cache
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,10 @@
     }
   ],
   "require": {
-    "php": ">=7.2.5"
+    "php": ">=8.1.0"
   },
   "require-dev": {
+    "phpstan/phpstan": "^1.11",
     "prestashop/php-dev-tools": "^4.3"
   },
   "autoload": {
@@ -28,7 +29,7 @@
     "optimize-autoloader": true,
     "prepend-autoloader": false,
     "platform": {
-      "php": "7.2.5"
+      "php": "8.1.0"
     }
   },
   "type": "prestashop-module"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3d16c505f06203a3197338f19075820",
+    "content-hash": "64b4098448e583df722a1aa2fd3f290a",
     "packages": [],
     "packages-dev": [
         {
@@ -619,6 +619,64 @@
             },
             "abandoned": true,
             "time": "2020-10-14T08:32:19+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/707c2aed5d8d0075666e673a5e71440c1d01a5a3",
+                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-19T14:37:29+00:00"
         },
         {
             "name": "prestashop/autoindex",
@@ -2415,11 +2473,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2.5"
+        "php": ">=8.1.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.5"
+        "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_linklist</name>
     <displayName><![CDATA[Link List]]></displayName>
-    <version><![CDATA[6.0.7]]></version>
+    <version><![CDATA[7.0.0]]></version>
     <description><![CDATA[Adds a block with several links.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -1,0 +1,143 @@
+services:
+  _defaults:
+    public: false
+    autowire: true
+    autoconfigure: true
+
+  PrestaShop\Module\LinkList\Controller\Admin\Improve\Design\LinkBlockController: ~
+
+  # Link block form handler
+  prestashop.module.link_block.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
+    arguments:
+      $formBuilder: '@=service("form.factory").createBuilder()'
+      $hookDispatcher: '@prestashop.core.hook.dispatcher'
+      $formDataProvider: '@PrestaShop\Module\LinkList\Form\LinkBlockFormDataProvider'
+      $formTypes:
+        'link_block': 'PrestaShop\Module\LinkList\Form\Type\LinkBlockType'
+      $hookName: 'AdminLinkWidget'
+
+  # Link block form data provider
+  PrestaShop\Module\LinkList\Form\LinkBlockFormDataProvider:
+    arguments:
+      $repository: '@PrestaShop\Module\LinkList\Repository\LinkBlockRepository'
+      $cache: '@PrestaShop\Module\LinkList\Cache\LegacyLinkBlockCache'
+      $languages: '@=service("prestashop.adapter.legacy.context").getLanguages(false, service("prestashop.adapter.shop.context").getContextShopID())'
+      $shopContext: '@prestashop.adapter.shop.context'
+      $configuration: '@prestashop.adapter.legacy.configuration'
+
+  PrestaShop\Module\LinkList\Cache\LegacyLinkBlockCache: ~
+
+  # Form types
+  PrestaShop\Module\LinkList\Form\Type\LinkBlockType:
+    parent: 'form.type.translatable.aware'
+    arguments:
+      $hookChoices: '@=service("prestashop.module.link_block.choice_provider.hook").getChoices()'
+      $cmsPageChoices: '@=service("prestashop.module.link_block.choice_provider.cms_page").getChoices()'
+      $productPageChoices: '@=service("prestashop.module.link_block.choice_provider.product_page").getChoices()'
+      $staticPageChoices: '@=service("prestashop.module.link_block.choice_provider.static_page").getChoices()'
+      $categoryChoices: '@=service("prestashop.module.link_block.choice_provider.category").getChoices()'
+      $isMultiStoreUsed: '@=service("prestashop.adapter.feature.multistore").isUsed()'
+    tags:
+      - { name: form.type }
+
+  PrestaShop\Module\LinkList\Form\Type\CustomUrlType:
+    parent: 'form.type.translatable.aware'
+    tags:
+      - { name: form.type }
+
+  PrestaShop\Module\LinkList\Form\Type\TranslateCustomUrlType:
+    parent: 'form.type.translatable.aware'
+    public: true
+    arguments:
+      - "@=service('prestashop.adapter.legacy.context').getAvailableLanguages()"
+      - '@router.default'
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_BO_ALLOW_EMPLOYEE_FORM_LANG')"
+      - "@=service('prestashop.adapter.legacy.context').getContext().cookie.employee_form_lang"
+      - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
+    tags:
+      - { name: form.type }
+
+  # Grid data query builder
+  prestashop.module.link_block.grid.query_builder:
+    class: PrestaShop\Module\LinkList\Core\Grid\Query\LinkBlockQueryBuilder
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+
+  # Grid Data Factory
+  prestashop.module.link_block.grid.data_factory:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      $gridQueryBuilder: '@prestashop.module.link_block.grid.query_builder'
+      $hookDispatcher: '@prestashop.core.hook.dispatcher'
+      $queryParser: '@prestashop.core.grid.query.doctrine_query_parser'
+      $gridId: 'link_block'
+
+  # Link block grid Factory
+  PrestaShop\Module\LinkList\Core\Grid\LinkBlockGridFactory:
+    arguments:
+      $translator: '@translator'
+      $hookDispatcher: '@prestashop.core.hook.dispatcher'
+      $dataFactory: '@prestashop.module.link_block.grid.data_factory'
+      $filterFormFactory: '@prestashop.core.grid.filter.form_factory'
+      $shopContext: '@prestashop.adapter.shop.context'
+
+  # Form choices providers
+  prestashop.module.link_block.choice_provider.hook:
+    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\HookChoiceProvider
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+
+  prestashop.module.link_block.choice_provider.cms_category:
+    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\CMSCategoryChoiceProvider
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+
+  prestashop.module.link_block.choice_provider.category:
+    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\CategoryChoiceProvider
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+
+  prestashop.module.link_block.choice_provider.cms_page:
+    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\CMSPageChoiceProvider
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+      $categories: '@=service("prestashop.module.link_block.choice_provider.cms_category").getChoices()'
+      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+
+  prestashop.module.link_block.choice_provider.product_page:
+    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\PageChoiceProvider
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+      $pageNames:
+        - 'prices-drop'
+        - 'new-products'
+        - 'best-sales'
+
+  prestashop.module.link_block.choice_provider.static_page:
+    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\PageChoiceProvider
+    arguments:
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
+      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+      $pageNames:
+        - 'contact'
+        - 'sitemap'
+        - 'stores'
+        - 'authentication'
+        - 'registration'
+        - 'my-account'

--- a/config/services.yml
+++ b/config/services.yml
@@ -2,11 +2,7 @@ services:
   _defaults:
     public: true
 
-  prestashop.module.link_block.cache:
-    class: PrestaShop\Module\LinkList\Cache\LegacyLinkBlockCache
-
-  prestashop.module.link_block.repository:
-    class: PrestaShop\Module\LinkList\Repository\LinkBlockRepository
+  PrestaShop\Module\LinkList\Repository\LinkBlockRepository:
     arguments:
       $connection: '@doctrine.dbal.default_connection'
       $dbPrefix: '%database_prefix%'
@@ -16,154 +12,8 @@ services:
       $multiStoreContext: '@prestashop.adapter.shop.context'
       $objectModelHandler: '@prestashop.module.link_block.adapter.object_model_handler'
 
-  # Grid data query builder
-  prestashop.module.link_block.grid.query_builder:
-    class: PrestaShop\Module\LinkList\Core\Grid\Query\LinkBlockQueryBuilder
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-
-  # Grid Data Factory
-  prestashop.module.link_block.grid.data_factory:
-    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
-    arguments:
-      $gridQueryBuilder: '@prestashop.module.link_block.grid.query_builder'
-      $hookDispatcher: '@prestashop.core.hook.dispatcher'
-      $queryParser: '@prestashop.core.grid.query.doctrine_query_parser'
-      $gridId: 'link_block'
-
-  # Link block grid Factory
-  prestashop.module.link_block.grid.factory:
-    class: PrestaShop\Module\LinkList\Core\Grid\LinkBlockGridFactory
-    arguments:
-      $translator: '@translator'
-      $hookDispatcher: '@prestashop.core.hook.dispatcher'
-      $dataFactory: '@prestashop.module.link_block.grid.data_factory'
-      $filterFormFactory: '@prestashop.core.grid.filter.form_factory'
-      $shopContext: '@prestashop.adapter.shop.context'
-
-  # Grid position definition
-  prestashop.module.link_block.grid.position_definition:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'
-    arguments:
-      $table: 'link_block'
-      $idField: 'id_link_block'
-      $positionField: 'position'
-      $parentIdField: 'id_hook'
-
-  # Link block form data provider
-  prestashop.module.link_block.form_provider:
-    class: PrestaShop\Module\LinkList\Form\LinkBlockFormDataProvider
-    arguments:
-      $repository: '@prestashop.module.link_block.repository'
-      $cache: '@prestashop.module.link_block.cache'
-      $languages: '@=service("prestashop.adapter.legacy.context").getLanguages(false, service("prestashop.adapter.shop.context").getContextShopID())'
-      $shopContext: '@prestashop.adapter.shop.context'
-      $configuration: '@prestashop.adapter.legacy.configuration'
-
-  # Form choices providers
-  prestashop.module.link_block.choice_provider.hook:
-    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\HookChoiceProvider
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-
-  prestashop.module.link_block.choice_provider.cms_category:
-    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\CMSCategoryChoiceProvider
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
-
-  prestashop.module.link_block.choice_provider.category:
-    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\CategoryChoiceProvider
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
-
-  prestashop.module.link_block.choice_provider.cms_page:
-    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\CMSPageChoiceProvider
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-      $categories: '@=service("prestashop.module.link_block.choice_provider.cms_category").getChoices()'
-      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
-
-  prestashop.module.link_block.choice_provider.product_page:
-    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\PageChoiceProvider
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
-      $pageNames:
-        - 'prices-drop'
-        - 'new-products'
-        - 'best-sales'
-
-  prestashop.module.link_block.choice_provider.static_page:
-    class: PrestaShop\Module\LinkList\Form\ChoiceProvider\PageChoiceProvider
-    arguments:
-      $connection: '@doctrine.dbal.default_connection'
-      $dbPrefix: '%database_prefix%'
-      $idLang: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      $shopIds: '@=service("prestashop.adapter.shop.context").getContextListShopID()'
-      $pageNames:
-        - 'contact'
-        - 'sitemap'
-        - 'stores'
-        - 'authentication'
-        - 'registration'
-        - 'my-account'
-
-  # Form types
-  prestashop.module.link_block.form_type:
-    class: PrestaShop\Module\LinkList\Form\Type\LinkBlockType
-    parent: 'form.type.translatable.aware'
-    public: true
-    arguments:
-      $hookChoices: '@=service("prestashop.module.link_block.choice_provider.hook").getChoices()'
-      $cmsPageChoices: '@=service("prestashop.module.link_block.choice_provider.cms_page").getChoices()'
-      $productPageChoices: '@=service("prestashop.module.link_block.choice_provider.product_page").getChoices()'
-      $staticPageChoices: '@=service("prestashop.module.link_block.choice_provider.static_page").getChoices()'
-      $categoryChoices: '@=service("prestashop.module.link_block.choice_provider.category").getChoices()'
-      $isMultiStoreUsed: '@=service("prestashop.adapter.feature.multistore").isUsed()'
-    tags:
-      - { name: form.type }
-
-  prestashop.module.link_block.custom_url_type:
-    class: PrestaShop\Module\LinkList\Form\Type\CustomUrlType
-    parent: 'form.type.translatable.aware'
-    public: true
-    tags:
-    - { name: form.type }
-
-  # Link block form handler
-  prestashop.module.link_block.form_handler:
-    class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
-    arguments:
-      $formBuilder: '@=service("form.factory").createBuilder()'
-      $hookDispatcher: '@prestashop.core.hook.dispatcher'
-      $formDataProvider: '@prestashop.module.link_block.form_provider'
-      $formTypes:
-        'link_block': 'PrestaShop\Module\LinkList\Form\Type\LinkBlockType'
-      $hookName: 'AdminLinkWidget'
+  prestashop.module.link_block.repository:
+    alias: PrestaShop\Module\LinkList\Repository\LinkBlockRepository
 
   prestashop.module.link_block.adapter.object_model_handler:
     class: 'PrestaShop\Module\LinkList\Adapter\ObjectModelHandler'
-
-  PrestaShop\Module\LinkList\Form\Type\TranslateCustomUrlType:
-    parent: 'form.type.translatable.aware'
-    public: true
-    arguments:
-      - "@=service('prestashop.adapter.legacy.context').getAvailableLanguages()"
-      - '@router.default'
-      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_BO_ALLOW_EMPLOYEE_FORM_LANG')"
-      - "@=service('prestashop.adapter.legacy.context').getContext().cookie.employee_form_lang"
-      - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
-    tags:
-      - { name: form.type }

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -73,7 +73,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $this->name = 'ps_linklist';
         $this->author = 'PrestaShop';
-        $this->version = '6.0.7';
+        $this->version = '7.0.0';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
 
@@ -99,7 +99,7 @@ class Ps_Linklist extends Module implements WidgetInterface
         $this->displayName = $this->trans('Link List', [], 'Modules.Linklist.Admin');
         $this->description = $this->trans('Give more visibility to your content/static pages (CMS, external pages, or else), where you want and when you want, to make your visitors feel like shopping on your store.', [], 'Modules.Linklist.Admin');
 
-        $this->ps_versions_compliancy = ['min' => '8.1.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '9.0.0', 'max' => _PS_VERSION_];
         $this->templateFile = 'module:ps_linklist/views/templates/hook/linkblock.tpl';
         $this->templateFileColumn = 'module:ps_linklist/views/templates/hook/linkblock-column.tpl';
 

--- a/src/Controller/Admin/Improve/Design/LinkBlockController.php
+++ b/src/Controller/Admin/Improve/Design/LinkBlockController.php
@@ -27,7 +27,7 @@ use PrestaShop\Module\LinkList\Repository\LinkBlockRepository;
 use PrestaShop\PrestaShop\Core\Exception\DatabaseException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,15 +35,14 @@ use Symfony\Component\HttpFoundation\Response;
 class LinkBlockController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param Request $request
      *
      * @return Response
      */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function listAction(Request $request)
     {
-        //Get hook list, then loop through hooks setting it in in the filter
+        //Get hook list, then loop through hooks setting it in the filter
         /** @var LinkBlockRepository $repository */
         $repository = $this->get('prestashop.module.link_block.repository');
         $hooks = $repository->getHooksWithLinks();
@@ -75,14 +74,13 @@ class LinkBlockController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param Request $request
      *
      * @return Response
      *
      * @throws \Exception
      */
+    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function createAction(Request $request)
     {
         $this->get('prestashop.module.link_block.form_provider')->setIdLinkBlock(null);
@@ -97,8 +95,6 @@ class LinkBlockController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param Request $request
      * @param int $linkBlockId
      *
@@ -106,6 +102,7 @@ class LinkBlockController extends FrameworkBundleAdminController
      *
      * @throws \Exception
      */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function editAction(Request $request, $linkBlockId)
     {
         $this->get('prestashop.module.link_block.form_provider')->setIdLinkBlock($linkBlockId);
@@ -120,22 +117,19 @@ class LinkBlockController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param Request $request
      *
      * @return RedirectResponse|Response
      *
      * @throws \Exception
      */
+    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function createProcessAction(Request $request)
     {
         return $this->processForm($request, 'Successful creation.');
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param Request $request
      * @param int $linkBlockId
      *
@@ -143,18 +137,18 @@ class LinkBlockController extends FrameworkBundleAdminController
      *
      * @throws \Exception
      */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function editProcessAction(Request $request, $linkBlockId)
     {
         return $this->processForm($request, 'Successful update.', $linkBlockId);
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param int $linkBlockId
      *
      * @return RedirectResponse
      */
+    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function deleteAction($linkBlockId)
     {
         $repository = $this->get('prestashop.module.link_block.repository');
@@ -180,8 +174,6 @@ class LinkBlockController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="Access denied.")
-     *
      * @param Request $request
      * @param int $hookId
      *
@@ -189,6 +181,7 @@ class LinkBlockController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_homepage')]
     public function updatePositionsAction(Request $request, $hookId)
     {
         $positionsData = [

--- a/src/Form/LinkBlockFormDataProvider.php
+++ b/src/Form/LinkBlockFormDataProvider.php
@@ -216,20 +216,12 @@ class LinkBlockFormDataProvider implements FormDataProviderInterface
         return [];
     }
 
-    /**
-     * @return int
-     */
-    public function getIdLinkBlock()
+    public function getIdLinkBlock(): ?int
     {
         return $this->idLinkBlock;
     }
 
-    /**
-     * @param int $idLinkBlock
-     *
-     * @return LinkBlockFormDataProvider
-     */
-    public function setIdLinkBlock($idLinkBlock)
+    public function setIdLinkBlock(?int $idLinkBlock)
     {
         $this->idLinkBlock = $idLinkBlock;
 

--- a/src/LegacyLinkBlockRepository.php
+++ b/src/LegacyLinkBlockRepository.php
@@ -144,7 +144,7 @@ class LegacyLinkBlockRepository
     /**
      * @return bool
      */
-    public function installFixtures()
+    public function installFixtures(): bool
     {
         $success = true;
         $id_hook = (int) Hook::getIdByName('displayFooter');
@@ -168,7 +168,7 @@ class LegacyLinkBlockRepository
         }
 
         foreach ($queries as $query) {
-            $success &= $this->db->execute($query);
+            $success = $success && ((bool) $this->db->execute($query));
         }
 
         return $success;

--- a/tests/phpstan.sh
+++ b/tests/phpstan.sh
@@ -1,28 +1,40 @@
 #!/bin/bash
-PS_VERSION=$1
-
 set -e
 
-# Docker images prestashop/prestashop may be used, even if the shop remains uninstalled
+if [ $# -le 0 ]; then
+  echo "No version provided. Use:"
+  echo "tests/phpstan/phpstan.sh [PrestaShop_version]"
+  exit 1
+fi
+
+PS_VERSION=$1
+BASEDIR=$(dirname "$0")
+MODULEDIR=$(cd $BASEDIR/.. && pwd)
+
+if [ ! -f $MODULEDIR/tests/phpstan/phpstan-$PS_VERSION.neon ]; then
+  echo "Configuration file for PrestaShop $PS_VERSION does not exist."
+  echo "Please try another version."
+  exit 2
+fi
+
+# Docker images prestashop/prestashop are used to get source files
 echo "Pull PrestaShop files (Tag ${PS_VERSION})"
 
 docker rm -f temp-ps || true
-docker volume rm -f ps-volume || true
-
-docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop:$PS_VERSION
+docker run -tid --rm --name temp-ps prestashop/prestashop:$PS_VERSION
+until docker exec -t temp-ps ls /var/www/html/modules/ps_linklist 2>&1 > /dev/null; do echo 'Wait for extraction'; sleep 2; done
 
 # Clear previous instance of the module in the PrestaShop volume
-echo "Clear previous module"
-
+echo "Clear previous module and copy current one"
 docker exec -t temp-ps rm -rf /var/www/html/modules/ps_linklist
-
-# Run a container for PHPStan, having access to the module content and PrestaShop sources.
-# This tool is outside the composer.json because of the compatibility with PHP 5.6
+docker exec -t temp-ps mkdir -p /var/www/html/modules/ps_linklist
+docker cp $MODULEDIR temp-ps:/var/www/html/modules/
 echo "Run PHPStan using phpstan-${PS_VERSION}.neon file"
 
-docker run --rm --volumes-from temp-ps \
-       -v $PWD:/var/www/html/modules/ps_linklist \
-       -e _PS_ROOT_DIR_=/var/www/html \
-       --workdir=/var/www/html/modules/ps_linklist phpstan/phpstan:0.12 \
-       analyse \
-       --configuration=/var/www/html/modules/ps_linklist/tests/phpstan/phpstan-$PS_VERSION.neon
+docker exec \
+      -e _PS_ROOT_DIR_=/var/www/html \
+      --workdir=/var/www/html/modules/ps_linklist \
+      temp-ps \
+      ./vendor/bin/phpstan analyse \
+      --configuration=/var/www/html/modules/ps_linklist/tests/phpstan/phpstan-$PS_VERSION.neon \
+      "${@:2}"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | - Replace security annotations with attributes<br/>- Refacto controller to new base class `PrestaShopAdminController`<br/>- Refacto service definitions to use FQCN and autowiring<br/>- New minimum version of PrestaShop is now 9.0.0<br>- New minimum version of PHP is now 8.1.0<br>- Fix PHPStan CI to work with PSV9 and PHP 8.1
| Type?         | improvement
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
