### PR TITLE
Add nullable types for PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,12 +49,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['nightly']
+        presta-version: [ 'nightly', '9.0.x' ]
+        # The 8.4 compatibility is not available yet, this should be uncommented whe the dockers are ready
+        # php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-version: [ '8.1', '8.2', '8.3' ]
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php-version }})
 
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -76,5 +79,5 @@ jobs:
       - run: composer install
 
       # Docker images prestashop/prestashop may be used, even if the shop remains uninstalled
-      - name: Execute PHPStan on PrestaShop (Tag ${{ matrix.presta-versions }})
-        run: ./tests/phpstan.sh ${{ matrix.presta-versions }} --error-format=github
+      - name: Execute PHPStan on PrestaShop (Tag ${{ matrix.presta-version }}-${{ matrix.php-version }}))
+        run: ./tests/phpstan.sh ${{ matrix.presta-version }} ${{ matrix.php-version }}

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_linklist</name>
     <displayName><![CDATA[Link List]]></displayName>
-    <version><![CDATA[7.0.0]]></version>
+    <version><![CDATA[7.0.1]]></version>
     <description><![CDATA[Adds a block with several links.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_linklist.php
+++ b/ps_linklist.php
@@ -73,7 +73,7 @@ class Ps_Linklist extends Module implements WidgetInterface
     {
         $this->name = 'ps_linklist';
         $this->author = 'PrestaShop';
-        $this->version = '7.0.0';
+        $this->version = '7.0.1';
         $this->need_instance = 0;
         $this->tab = 'front_office_features';
 

--- a/src/Core/Grid/Query/LinkBlockQueryBuilder.php
+++ b/src/Core/Grid/Query/LinkBlockQueryBuilder.php
@@ -35,7 +35,7 @@ final class LinkBlockQueryBuilder extends AbstractDoctrineQueryBuilder
      *
      * @return QueryBuilder
      */
-    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
+    public function getSearchQueryBuilder(?SearchCriteriaInterface $searchCriteria = null)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
         $qb->select('
@@ -70,7 +70,7 @@ final class LinkBlockQueryBuilder extends AbstractDoctrineQueryBuilder
      *
      * @return QueryBuilder
      */
-    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria = null)
+    public function getCountQueryBuilder(?SearchCriteriaInterface $searchCriteria = null)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
         $qb->select('COUNT(DISTINCT(lb.id_link_block))');

--- a/src/Form/ChoiceProvider/AbstractDatabaseChoiceProvider.php
+++ b/src/Form/ChoiceProvider/AbstractDatabaseChoiceProvider.php
@@ -56,7 +56,7 @@ abstract class AbstractDatabaseChoiceProvider implements FormChoiceProviderInter
      * @param int|null $idLang
      * @param array|null $shopIds
      */
-    public function __construct(Connection $connection, $dbPrefix, $idLang = null, array $shopIds = null)
+    public function __construct(Connection $connection, $dbPrefix, $idLang = null, ?array $shopIds = null)
     {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;

--- a/src/Presenter/LinkBlockPresenter.php
+++ b/src/Presenter/LinkBlockPresenter.php
@@ -41,7 +41,7 @@ class LinkBlockPresenter
      * @param \Link $link
      * @param \Language $language
      */
-    public function __construct(\Link $link, \Language $language, LinkFilter $linkFilter = null)
+    public function __construct(\Link $link, \Language $language, ?LinkFilter $linkFilter = null)
     {
         $this->link = $link;
         $this->language = $language;

--- a/tests/phpstan/phpstan-9.0.x.neon
+++ b/tests/phpstan/phpstan-9.0.x.neon
@@ -1,0 +1,2 @@
+includes:
+	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add nullable types for PHP 8.4 compatibility
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
