### PR TITLE
Fix: BO > linklist - Position ID starts from 2 instead of 1

### DIFF
--- a/src/Repository/LinkBlockRepository.php
+++ b/src/Repository/LinkBlockRepository.php
@@ -191,10 +191,18 @@ class LinkBlockRepository
         $this->updateLanguages($linkBlockId, $data['block_name'], $data['custom_content']);
 
         if ($this->isMultiStoreUsed) {
+            $unassociatedShopIds = $this->getUnassociatedShopIds($linkBlockId);
             $this->objectModelHandler->handleMultiShopAssociation(
                 $linkBlockId,
                 $data['shop_association']
             );
+
+            // Intersects shops that were not previously associated with those just selected,
+            // so that the position is updated only for the newly added shops.
+            $shopIds = array_intersect($unassociatedShopIds, $data['shop_association']);
+            if ($shopIds) {
+                $this->updateMaxPosition((int) $linkBlockId, (int) $data['id_hook'], $shopIds);
+            }
         }
     }
 
@@ -436,18 +444,25 @@ class LinkBlockRepository
     private function getHookMaxPosition(int $idHook, int $idShop): int
     {
         $qb = $this->connection->createQueryBuilder();
-        $qb->select('MAX(lbs.position)')
+
+        $qb->select('COUNT(lbs.id_link_block) AS total, MAX(lbs.position) AS max_position')
             ->from($this->dbPrefix . 'link_block_shop', 'lbs')
             ->leftJoin('lbs', $this->dbPrefix . 'link_block', 'lb', 'lbs.id_link_block = lb.id_link_block')
             ->andWhere('lb.id_hook = :idHook')
             ->andWhere('lbs.id_shop = :idShop')
             ->setParameter('idHook', $idHook)
-            ->setParameter('idShop', $idShop)
-        ;
+            ->setParameter('idShop', $idShop);
 
-        $maxPosition = $qb->execute()->fetch(\PDO::FETCH_COLUMN);
+        $result = $qb->execute()->fetchAssociative();
 
-        return null !== $maxPosition ? $maxPosition + 1 : 0;
+        $total = (int) ($result['total'] ?? 0);
+        $maxPosition = (int) ($result['max_position'] ?? 0);
+
+        if ($total <= 1) {
+            return 0;
+        }
+
+        return $maxPosition + 1;
     }
 
     /**
@@ -510,5 +525,26 @@ class LinkBlockRepository
 
             throw new DatabaseException('Could not update positions.');
         }
+    }
+
+    private function getUnassociatedShopIds(
+        int $linkBlockId
+    ) {
+        $qb = $this->connection->createQueryBuilder();
+
+        $qb->select('s.id_shop')
+            ->from($this->dbPrefix . 'shop', 's')
+            ->leftJoin(
+                's',
+                $this->dbPrefix . 'link_block_shop',
+                'lbs',
+                's.id_shop = lbs.id_shop AND lbs.id_link_block = :idLinkBlock'
+            )
+            ->where('lbs.id_shop IS NULL')
+            ->setParameter('idLinkBlock', $linkBlockId);
+
+        $rows = $qb->execute()->fetchAllAssociative();
+
+        return array_column($rows, 'id_shop');
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR correctly sets the position to 0 when creating a new block (previously it was set to 1) and also assigns the position during update for shops that were not previously associated.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#36524
| How to test?  | **Case 1:**  <br/>1. Create a new link block.<br/>2. Check the position displayed in the list — it should be **1** and not **2**.<br/>   (See [#36524](https://github.com/PrestaShop/PrestaShop/issues/36524) for more details.)<br/><br/>**Case 2:** <br/>1. Enable **Multistore** and create a second shop.<br/>2. Create **two link blocks**, associating them with **only one shop**.<br/>3. Edit both link blocks and associate them also with the **other shop**.<br/>4. Verify that the **positions** are correctly assigned for each shop.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
